### PR TITLE
Bump argo-workflows from 0.10.1 to 0.13.1, argo-events from 1.10.0 to 1.12.0

### DIFF
--- a/charts.yaml
+++ b/charts.yaml
@@ -1,8 +1,8 @@
 - name: argo-workflows
   repo: argo
   url: https://argoproj.github.io/argo-helm
-  version: 0.10.1
+  version: 0.13.1
 - name: argo-events
   repo: argo
   url: https://argoproj.github.io/argo-helm
-  version: 1.10.0
+  version: 1.12.0


### PR DESCRIPTION
## Terraform Helm Updater
Bumps argo-workflows Helm Chart version from 0.10.1 to 0.13.1.
## Terraform Helm Updater
Bumps argo-events Helm Chart version from 1.10.0 to 1.12.0.
