### PR TITLE
Bump argo-workflows from 0.10.1 to 0.13.1, argo-events from 1.10.0 to 1.12.0, external-dns from 1.6.0 to 1.7.1, aws-load-balancer-controller from 1.3.3 to 1.4.1, aws-vpc-cni from 1.1.9 to 1.1.14

### DIFF
--- a/charts.yaml
+++ b/charts.yaml
@@ -10,11 +10,3 @@
   repo: external-dns
   url: https://kubernetes-sigs.github.io/external-dns/
   version: 1.7.1
-- name: aws-load-balancer-controller
-  repo: eks-charts
-  url: https://aws.github.io/eks-charts
-  version: 1.4.1
-- name: aws-vpc-cni
-  repo: eks-charts
-  url: https://aws.github.io/eks-charts
-  version: 1.1.14

--- a/charts.yaml
+++ b/charts.yaml
@@ -1,20 +1,20 @@
 - name: argo-workflows
   repo: argo
   url: https://argoproj.github.io/argo-helm
-  version: 0.10.1
+  version: 0.13.1
 - name: argo-events
   repo: argo
   url: https://argoproj.github.io/argo-helm
-  version: 1.10.0
+  version: 1.12.0
 - name: external-dns
   repo: external-dns
   url: https://kubernetes-sigs.github.io/external-dns/
-  version: 1.6.0
+  version: 1.7.1
 - name: aws-load-balancer-controller
   repo: eks-charts
   url: https://aws.github.io/eks-charts
-  version: 1.3.3
+  version: 1.4.1
 - name: aws-vpc-cni
   repo: eks-charts
   url: https://aws.github.io/eks-charts
-  version: 1.1.9
+  version: 1.1.14

--- a/images.yaml
+++ b/images.yaml
@@ -1,0 +1,48 @@
+- registry: quay.io
+  name: argoproj/workflow-controller
+  digests:
+    amd64: sha256:2b8715e71040e332b0faea68f0724bf7c6e193a61d5babecac03a6d68fe86efc
+    arm64: sha256:614275080106101e49c8227a98d12951a73a4c3a9456dc684cff8775a543a35c
+- registry: quay.io
+  name: argoproj/argoexec
+  digests:
+    amd64: sha256:718c36f2fdd4730c0df544a221f55b6e837447b483d805f83bc270029797db88
+    arm64: sha256:1a90d6055480de3f3d1288fd6b8093079ec6fefc4d63dc8cc6510e42dded356f
+- registry: quay.io
+  name: argoproj/argocli
+  digests:
+    amd64: sha256:6d88af1c3af3835a14b229cfa5100032a364e1613bdbdf6d6f57197def8dc06f
+    arm64: sha256:22750b5bf703e8a9eba71a4b4d9d67bfcbbc46284ecece12dff5b540845d815d
+- registry: quay.io
+  name: argoproj/argo-events
+  digests:
+    amd64: sha256:1ccaabebb00221e388000bca20e8be2388fdec417285cc3476ef63495d1f739f
+    arm64: sha256:1700d08ef7a2395ea3ba6825275853904c20461ad55dfde04c9d52f13ad4ba5a
+- name: library/nats-streaming
+  digests:
+    amd64: sha256:3c6c9375f9e9724462e98cfb98a7abb50ceeca73b3070ce061992c4009e32157
+    arm64: sha256:96652223cce95275138363a54affb8663ba46bc75831c2a9535375ab6d922143
+- name: natsio/prometheus-nats-exporter
+  digests:
+    amd64: sha256:f8226945daddf0c11a66470a2ea1fd985f986fb45eeadac52c941455c35f8fc4
+    arm64: sha256:55bbea79b8537a09f469dd92cdb474cc26fa5dc8f0b5ba38942bf3623e7fe156
+- registry: k8s.gcr.io
+  name: external-dns/external-dns
+  digests:
+    amd64: sha256:4cf7d828f7c26f62bce71fa69a53c327d1d036af3ab45d712342041b4bec3884
+    arm64: sha256:20cf87ac432a82a7221350a60753a2c2888493ce05775d59ca58a1cc011ee97f
+- registry: 602401143452.dkr.ecr.us-west-2.amazonaws.com
+  name: amazon/aws-load-balancer-controller
+  digests:
+    amd64: sha256:39d0df6a845726af6d91bafb40c0bcb211d148cc75cb77f90ca6b113782c2ca1
+    arm64: sha256:1bccd59c3d810f6e21d40b7d1873bd880dd1fe5e6cecfc570163cc54ab9146c0
+- registry: 602401143452.dkr.ecr.us-west-2.amazonaws.com
+  name: amazon-k8s-cni-init
+  digests:
+    amd64: sha256:47436b9f9007605ff65c47bfdd027a4f5ebef9632cbbe58880de5277ab0fcfd7
+    arm64: sha256:4cf4edaaebad3afc7f2810551838b839b8049d605b56e8450c490e43bd4b8d69
+- registry: 602401143452.dkr.ecr.us-west-2.amazonaws.com
+  name: amazon-k8s-cni
+  digests:
+    amd64: sha256:070377b12ec1ca1dfc6f8fa2dc389a9079de10a7950aecbbe562bfe51ed5ff6e
+    arm64: sha256:3511ac37a330b89865b5c28992ee34b76929abdccc051fd8b5dcf5d221c67e83


### PR DESCRIPTION
## Terraform Helm Updater
Bumps argo-workflows Helm Chart version from 0.10.1 to 0.13.1.
Bumps argo-events Helm Chart version from 1.10.0 to 1.12.0.
Bumps external-dns Helm Chart version from 1.6.0 to 1.7.1.
Bumps aws-load-balancer-controller Helm Chart version from 1.3.3 to 1.4.1.
Bumps aws-vpc-cni Helm Chart version from 1.1.9 to 1.1.14.

---
Also updated list of image digests.